### PR TITLE
Lookup definition in struct part of kind.

### DIFF
--- a/reflect.go
+++ b/reflect.go
@@ -100,10 +100,6 @@ func ReflectFromObjType(objtype *rpcreflect.ObjType) *Schema {
 type Definitions map[string]*Type
 
 func reflectTypeToSchema(definitions Definitions, t reflect.Type) *Type {
-	if _, ok := definitions[t.Name()]; ok {
-		return &Type{Ref: "#/definitions/" + t.Name()}
-	}
-
 	switch t.Kind() {
 	case reflect.Struct:
 		switch t {
@@ -117,6 +113,10 @@ func reflectTypeToSchema(definitions Definitions, t reflect.Type) *Type {
 			return &Type{Type: "string", Format: "uri"}
 
 		default:
+			if _, ok := definitions[t.Name()]; ok {
+				return &Type{Ref: "#/definitions/" + t.Name()}
+			}
+
 			return reflectStruct(definitions, t)
 		}
 


### PR DESCRIPTION
In the develop branch of Juju we introduced the core/life type to the apiserver/params package. There was an issue where a life.Value was being interpreted as a constraints.Value rather than the string that it was.

This branch doesn't deal with struct name conflicts, it just moves the place where we look for similar names of structures to the struct kind part of the case statement. 

I have rebuild the Juju schema with this change and can confirm the only change is the fixup of the life type.